### PR TITLE
Updated package-lock.json to reflect correct @frctl/twig dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
     },
     "@frctl/twig": {
       "version": "github:frctl/twig#5bc5ed13af86caf4ce36f457738ecb0a627079cc",
-      "from": "github:frctl/twig",
+      "from": "github:frctl/twig#5bc5ed1",
       "requires": {
         "lodash": "^4.17.10",
         "twig": "^1.14.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,12 +104,11 @@
       }
     },
     "@frctl/twig": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@frctl/twig/-/twig-1.0.0-beta.5.tgz",
-      "integrity": "sha512-dhFhAcmrFbn+rxbJKSJVhWlxKVrwltHHLT9HmpQGoNTzNvrUdnhcqXmhVceBVD00KK8gVSkaA0ypAWGKDkmsOw==",
+      "version": "github:frctl/twig#5bc5ed13af86caf4ce36f457738ecb0a627079cc",
+      "from": "github:frctl/twig",
       "requires": {
         "lodash": "^4.17.10",
-        "twig": "^1.12.0"
+        "twig": "^1.14.0"
       }
     },
     "@gulp-sourcemaps/identity-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,9 +104,9 @@
       }
     },
     "@frctl/twig": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@frctl/twig/-/twig-1.0.0.tgz",
-      "integrity": "sha512-+Et0WliNlUE6MxL8XsDbqenzmQXO4Jc5VKzRJyBCQ+sQkyqB6lOHbQkBB/iDZDhbwjKqVOupZvrpNcE61F16LA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@frctl/twig/-/twig-1.0.0-beta.5.tgz",
+      "integrity": "sha512-dhFhAcmrFbn+rxbJKSJVhWlxKVrwltHHLT9HmpQGoNTzNvrUdnhcqXmhVceBVD00KK8gVSkaA0ypAWGKDkmsOw==",
       "requires": {
         "lodash": "^4.17.10",
         "twig": "^1.12.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@frctl/consolidate": "^1.0.1",
     "@frctl/fractal": "^1.1.7",
     "@frctl/mandelbrot": "^1.2.0",
-    "@frctl/twig": "github:frctl/twig",
+    "@frctl/twig": "github:frctl/twig#5bc5ed1",
     "@wearewondrous/fractal-twig-drupal-adapter": "^1.3.3",
     "del": "^3.0.0",
     "gulp": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@frctl/consolidate": "^1.0.1",
     "@frctl/fractal": "^1.1.7",
     "@frctl/mandelbrot": "^1.2.0",
-    "@frctl/twig": "^1.0.0-beta.5",
+    "@frctl/twig": "github:frctl/twig",
     "@wearewondrous/fractal-twig-drupal-adapter": "^1.3.3",
     "del": "^3.0.0",
     "gulp": "^4.0.0",


### PR DESCRIPTION
Hopefully this fixes the issues you indicated in Slack @bspeare. Otherwise, we are going to have to switch to pulling the @frctl/twig package via Github link to pull the master branch.